### PR TITLE
fixed translation array htmlentities

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -95,9 +95,12 @@ class Sitemap
 
             if ($translation)
             {
-                foreach ($translation as $key => $value)
+                foreach ($translation as $k => $trans)
                 {
-                    $translation[$key] = htmlentities($value, ENT_XML1);
+                    foreach ($trans as $key => $value)
+                    {
+                        $translation[$k][$key] = htmlentities($value, ENT_XML1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
updated the htmlentities parsing on the translation array according to the following translation template:

```
$translations= array(
    array(
        'url'=>'http://domain.com/en/topic',
        'language'=>'en'
    ),
    array(
        'url'=>'http://domain.com/topic',
        'language'=>'hr'
    )
);
```

(snippet taken from http://mariobasic.com/generate-a-sitemap-using-laravel/ )
